### PR TITLE
add support for inheritance, deserializing data into its class without knowing which class it is beforehand

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -657,6 +657,7 @@ class JsonSchemaMixin:
                 "type": "object",
                 "required": required,
                 "properties": properties,
+                "additionalProperties": False,
             }
 
             if cls.__doc__:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,11 +64,11 @@ class Bar(JsonSchemaMixin):
     a: Union[Weekday, Point]
 
 
-# @dataclass
-# class Baz(JsonSchemaMixin):
-#     """Type with nested default value"""
+@dataclass
+class Baz(JsonSchemaMixin):
+    """Type with nested default value"""
 
-#     a: Point = field(default=Point(0.0, 0.0))
+    a: Point = field(default=Point(0.0, 0.0))
 
 
 @dataclass
@@ -107,8 +107,8 @@ class ProductList(JsonSchemaMixin):
     products: Dict[UUID, Product]
 
 
-# @dataclass
-# class Zoo(JsonSchemaMixin):
-#     """A zoo"""
+@dataclass
+class Zoo(JsonSchemaMixin):
+    """A zoo"""
 
-#     animal_types: Optional[Dict[str, str]] = field(default_factory=dict)
+    animal_types: Optional[Dict[str, str]] = field(default_factory=dict)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -14,6 +14,8 @@ from .conftest import (
     Bar,
     Weekday,
     JsonSchemaMixin,
+    Zoo,
+    Baz,
 )
 import pytest
 
@@ -52,6 +54,7 @@ FOO_SCHEMA = {
     },
     "type": "object",
     "required": ["a", "c", "d", "f", "g"],
+    "additionalProperties": False,
 }
 
 # Fixme: Fields in description no longer match
@@ -63,6 +66,7 @@ POINT_SCHEMA = {
         "y": {"type": "number", "description": "Point y coordinate"},
     },
     "required": ["z", "y"],
+    "additionalProperties": False,
 }
 
 RECURSIVE_SCHEMA = {
@@ -73,6 +77,7 @@ RECURSIVE_SCHEMA = {
     },
     "type": "object",
     "required": ["a"],
+    "additionalProperties": False,
 }
 
 OPAQUE_DATA_SCHEMA = {
@@ -80,6 +85,7 @@ OPAQUE_DATA_SCHEMA = {
     "properties": {"a": {"type": "array"}, "b": {"type": "object"}},
     "type": "object",
     "required": ["a", "b"],
+    "additionalProperties": False,
 }
 
 PRODUCT_SCHEMA = {
@@ -90,6 +96,7 @@ PRODUCT_SCHEMA = {
     },
     "required": ["name"],
     "type": "object",
+    "additionalProperties": False,
 }
 
 SHOPPING_CART_SCHEMA = {
@@ -99,6 +106,7 @@ SHOPPING_CART_SCHEMA = {
     },
     "required": ["items"],
     "type": "object",
+    "additionalProperties": False,
 }
 PRODUCT_LIST_SCHEMA = {
     "description": ProductList.__doc__,
@@ -110,6 +118,7 @@ PRODUCT_LIST_SCHEMA = {
     },
     "type": "object",
     "required": ["products"],
+    "additionalProperties": False,
 }
 BAR_SCHEMA = {
     "type": "object",
@@ -132,7 +141,39 @@ BAR_SCHEMA = {
         }
     },
     "required": ["a"],
+    "additionalProperties": False,
 }
+ZOO_SCHEMA = {
+    "type": "object",
+    "description": "A zoo",
+    "properties": {
+        "animal_types": {
+            "additionalProperties": {"type": "string"},
+            "type": "object",
+            "default": {},
+        }
+    },
+    "additionalProperties": False,
+}
+BAZ_SCHEMA = {
+    "description": "Type with nested default value",
+    "properties": {
+        "a": {"$ref": "#/definitions/Point", "default": {"z": 0.0, "y": 0.0}}
+    },
+    "type": "object",
+    "additionalProperties": False,
+}
+
+
+def test_field_with_default_factory():
+    assert Zoo(animal_types={}) == Zoo.from_dict({})
+    assert Zoo(
+        animal_types={"snake": "reptile", "dog": "mammal"}
+    ) == Zoo.from_dict({"animal_types": {"snake": "reptile", "dog": "mammal"}})
+
+
+def test_field_with_default_dataclass():
+    assert Baz(a=Point(0.0, 0.0)) == Baz.from_dict({})
 
 
 # def test_embeddable_json_schema():
@@ -147,6 +188,8 @@ BAR_SCHEMA = {
 #         'Bar': BAR_SCHEMA,
 #         'ShoppingCart': SHOPPING_CART_SCHEMA,
 #         'OpaqueData': OPAQUE_DATA_SCHEMA,
+#         'Zoo': ZOO_SCHEMA,
+#         'Baz': BAZ_SCHEMA
 #     }
 #     assert expected == JsonSchemaMixin.all_json_schemas()
 #     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
this doesn't fix the kwargs before positional args problem, but it makes inheritance a little easier. namely:

- fixes caching so that you can properly generate schemas for inherited dataclasses
- adds support for a `JsonSchemaMixin.from_dict({...})` that searches the available subclasses for a match

note that the second breaks everything if you have a JSON schema with additionalProperties: true and all defaults. if you have that registered, every call to `JsonSchemaMixin.from_dict` will return you that thing

we should probably set additionalProperties: false by default to address this