### PR TITLE
Add some helper classes

### DIFF
--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,0 +1,54 @@
+import pytest
+
+from dataclasses import dataclass
+
+from hologram import ValidationError, JsonSchemaMixin
+from hologram.helpers import ExtensibleJsonSchemaMixin
+
+
+@dataclass
+class Extensible(ExtensibleJsonSchemaMixin):
+    a: str
+    b: int
+
+
+@dataclass
+class Inextensible(JsonSchemaMixin):
+    a: str
+    b: int
+
+
+@pytest.fixture
+def extensible_dict():
+    return {"a": "one", "b": 1}
+
+
+@pytest.fixture
+def extra_data(extensible_dict):
+    extra = dict(extensible_dict)
+    extra["c"] = []
+    return extra
+
+
+@pytest.fixture
+def extensible():
+    return Extensible(a="one", b=1)
+
+
+@pytest.fixture
+def inextensible():
+    return Inextensible(a="one", b=1)
+
+
+def test_extensible(extra_data, extensible_dict, extensible):
+    assert Extensible.from_dict(extra_data) == extensible
+    assert Extensible.from_dict(extensible_dict) == extensible
+    assert extensible.to_dict() == extensible_dict
+    assert Extensible.from_dict(extra_data).to_dict() == extensible_dict
+
+
+def test_inextensible(extra_data, extensible_dict, inextensible):
+    assert Inextensible.from_dict(extensible_dict) == inextensible
+    assert inextensible.to_dict() == extensible_dict
+    with pytest.raises(ValidationError):
+        Inextensible.from_dict(extra_data)

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,38 @@
+import pytest
+
+from dataclasses import dataclass
+
+from hologram import ValidationError, JsonSchemaMixin
+from hologram.helpers import NewPatternType
+
+
+Uppercase = NewPatternType("Uppercase", r"[A-Z]+")
+
+
+@dataclass
+class Loud(JsonSchemaMixin):
+    shouting: Uppercase
+    normal: str
+
+
+@pytest.fixture
+def loud():
+    return Loud(shouting="SHOUTING", normal="Normal")
+
+
+@pytest.fixture
+def loud_dict():
+    return {"shouting": "SHOUTING", "normal": "Normal"}
+
+
+@pytest.fixture
+def too_quiet():
+    return {"shouting": "shhhhh", "normal": "Normal"}
+
+
+def test_loud(loud, loud_dict, too_quiet):
+    assert loud.to_dict() == loud_dict
+    assert Loud.from_dict(loud_dict) == loud
+
+    with pytest.raises(ValidationError):
+        Loud.from_dict(too_quiet)

--- a/tests/test_underscore_hyphens.py
+++ b/tests/test_underscore_hyphens.py
@@ -1,0 +1,57 @@
+import pytest
+
+from dataclasses import dataclass, field
+from hologram import JsonSchemaMixin, ValidationError
+from hologram.helpers import HyphenatedJsonSchemaMixin
+
+
+@dataclass
+class HasUnderscoreConverts(HyphenatedJsonSchemaMixin):
+    a_thing: str = field(metadata={"preserve_underscore": True})
+    other_thing: str
+
+
+@dataclass
+class ContainsHasUnderscoreConverts(JsonSchemaMixin):
+    things: HasUnderscoreConverts
+
+
+@pytest.fixture
+def underscore():
+    return HasUnderscoreConverts(a_thing="foo", other_thing="bar")
+
+
+@pytest.fixture
+def underscore_dict():
+    return {"a_thing": "foo", "other-thing": "bar"}
+
+
+@pytest.fixture
+def contains(underscore):
+    return ContainsHasUnderscoreConverts(things=underscore)
+
+
+@pytest.fixture
+def contains_dict(underscore_dict):
+    return {"things": underscore_dict}
+
+
+@pytest.fixture
+def bad_dict():
+    return {"a_thing": "foo", "other_thing": "bar"}
+
+
+def test_base(underscore, underscore_dict, bad_dict):
+    assert HasUnderscoreConverts.from_dict(underscore_dict) == underscore
+    assert underscore.to_dict() == underscore_dict
+
+    with pytest.raises(ValidationError):
+        HasUnderscoreConverts.from_dict(bad_dict)
+
+
+def test_nested(contains, contains_dict, bad_dict):
+    assert ContainsHasUnderscoreConverts.from_dict(contains_dict) == contains
+    assert contains.to_dict() == contains_dict
+
+    with pytest.raises(ValidationError):
+        ContainsHasUnderscoreConverts.from_dict({"things": bad_dict})


### PR DESCRIPTION
I'm making use of these in dbt, figured I'd upstream them:

 - `NewPatternType` for regex patterns, which acts like typing.NewType + register an encoder for it with the given pattern schema
 - `HyphenatedJsonSchemaMixin`, which overrides the field_mapping method to replace all underscores in field names with hyphens. It provides an opt-out metadata flag to avoid hyphenating single fields (This is nice for Project configs, for example)
 - `ExtensibleJsonSchemaMixin` - Exactly like our normal `JsonSchemaMixin`, except with the additonalProperties field set to True. We need this in a couple places where we consume opaque JSON objects that we only care about single fields in (registry results). It's a rare enough occurrence that I want to opt in to it, not opt out. A subclass is kind of a clunky way to do this, but it seems hard to annotate types themselves with this info.