### PR TITLE
Update the cache in ExtensibleJsonSchemaMixin to handle embedded types

### DIFF
--- a/hologram/helpers.py
+++ b/hologram/helpers.py
@@ -48,5 +48,10 @@ class ExtensibleJsonSchemaMixin(JsonSchemaMixin):
     @classmethod
     def json_schema(cls, embeddable: bool = False) -> JsonDict:
         dct = super().json_schema(embeddable=embeddable)
-        dct["additionalProperties"] = True
+        cls._schema[cls.__name__]["additionalProperties"] = True
+
+        if embeddable:
+            dct[cls.__name__]["additionalProperties"] = True
+        else:
+            dct["additionalProperties"] = True
         return dct

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -18,6 +18,11 @@ class Inextensible(JsonSchemaMixin):
     b: int
 
 
+@dataclass
+class ContainsExtended(JsonSchemaMixin):
+    ext: Extensible
+
+
 @pytest.fixture
 def extensible_dict():
     return {"a": "one", "b": 1}
@@ -40,6 +45,21 @@ def inextensible():
     return Inextensible(a="one", b=1)
 
 
+@pytest.fixture
+def contains_extra_data(extra_data):
+    return {"ext": dict(extra_data)}
+
+
+@pytest.fixture
+def contains():
+    return ContainsExtended(ext=Extensible(a="one", b=1))
+
+
+@pytest.fixture
+def contains_dict(extensible_dict):
+    return {"ext": dict(extensible_dict)}
+
+
 def test_extensible(extra_data, extensible_dict, extensible):
     assert Extensible.from_dict(extra_data) == extensible
     assert Extensible.from_dict(extensible_dict) == extensible
@@ -52,3 +72,11 @@ def test_inextensible(extra_data, extensible_dict, inextensible):
     assert inextensible.to_dict() == extensible_dict
     with pytest.raises(ValidationError):
         Inextensible.from_dict(extra_data)
+
+
+def test_contains(contains_extra_data, contains_dict, contains):
+    assert ContainsExtended.from_dict(contains_dict) == contains
+    assert (
+        ContainsExtended.from_dict(contains_extra_data).to_dict()
+        == contains_dict
+    )

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -107,6 +107,7 @@ def test_tricky_unions():
         Thing(a="Thing2"),
     ]
     assert Unioned.from_dict(dcts).unioned == expected
+    assert Unioned.from_dict(dcts).to_dict() == dcts
 
 
 def test_nested_ok():
@@ -128,6 +129,8 @@ def test_nested_ok():
     result = Nested.from_dict(nested)
     assert result.top == expected
     assert result.first == Thing(a="Thing")
+
+    assert Nested.from_dict(nested).to_dict() == nested
 
 
 def test_bad_nested():


### PR DESCRIPTION
Before this PR, creating a type like `ContainsExtended` would have counter-intuitive results - the schema cache would have the old `False` value for `additionalProperties`.