### PR TITLE
Move registered encoders to be first

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -264,6 +264,7 @@ class JsonSchemaMixin:
                         cls._encode_field(ft.__args__[idx], v, o)
                         for idx, v in enumerate(val)
                     ]
+
             elif cls._is_json_schema_subclass(field_type):
                 # Only need to validate at the top level
                 def encoder(_, v, o):
@@ -337,7 +338,13 @@ class JsonSchemaMixin:
                 cls._decode_cache = {}
             # Replace any nested dictionaries with their targets
             field_type_name = cls._get_field_type_name(field_type)
-            if cls._is_json_schema_subclass(field_type):
+
+            if field_type in cls._field_encoders:
+
+                def decoder(_, ft, val):
+                    return cls._field_encoders[ft].to_python(val)
+
+            elif cls._is_json_schema_subclass(field_type):
 
                 def decoder(_, ft, val):
                     return ft.from_dict(val, validate=validate)
@@ -410,11 +417,6 @@ class JsonSchemaMixin:
 
                 def decoder(_, ft, val):
                     return ft(val)
-
-            elif field_type in cls._field_encoders:
-
-                def decoder(_, ft, val):
-                    return cls._field_encoders[ft].to_python(val)
 
             if decoder is None:
                 raise ValidationError(
@@ -520,8 +522,12 @@ class JsonSchemaMixin:
         field_schema: JsonDict = {"type": "object"}
 
         type_name = cls._get_field_type_name(target)
+
+        if target in cls._field_encoders:
+            field_schema.update(cls._field_encoders[target].json_schema)
+
         # if Union[..., None] or Optional[...]
-        if type_name == "Union":
+        elif type_name == "Union":
             field_schema = {
                 "oneOf": [
                     cls._get_field_schema(variant)[0]
@@ -584,9 +590,6 @@ class JsonSchemaMixin:
 
         elif target in JSON_ENCODABLE_TYPES:
             field_schema.update(JSON_ENCODABLE_TYPES[target])
-
-        elif target in cls._field_encoders:
-            field_schema.update(cls._field_encoders[target].json_schema)
 
         elif hasattr(target, "__supertype__"):  # NewType fields
             field_schema, _ = cls._get_field_schema(target.__supertype__)

--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -264,7 +264,6 @@ class JsonSchemaMixin:
                         cls._encode_field(ft.__args__[idx], v, o)
                         for idx, v in enumerate(val)
                     ]
-
             elif cls._is_json_schema_subclass(field_type):
                 # Only need to validate at the top level
                 def encoder(_, v, o):
@@ -418,7 +417,7 @@ class JsonSchemaMixin:
                     return cls._field_encoders[ft].to_python(val)
 
             if decoder is None:
-                warnings.warn(
+                raise ValidationError(
                     f"Unable to decode value for '{field}: {field_type_name}'"
                 )
                 return value
@@ -593,7 +592,7 @@ class JsonSchemaMixin:
             field_schema, _ = cls._get_field_schema(target.__supertype__)
 
         else:
-            warnings.warn(f"Unable to create schema for '{type_name}'")
+            raise ValidationError(f"Unable to create schema for '{type_name}'")
         return field_schema, required
 
     @classmethod

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,0 +1,70 @@
+from hologram import FieldEncoder, JsonSchemaMixin, ValidationError
+
+import pytest
+
+from dataclasses import dataclass
+from typing import NewType, List, Union
+
+
+ListOrTuple = NewType("ListOrTuple", List[str])
+
+
+class ListOrTupleEncoder(FieldEncoder):
+    def to_wire(self, value):
+        return list(value)
+
+    def to_python(self, value):
+        return value
+
+    @property
+    def json_schema(self):
+        return {"type": "array", "items": {"type": "string"}}
+
+
+class ListOrTupleOrAloneEncoder(FieldEncoder):
+    def to_wire(self, value):
+        if isinstance(value, (tuple, list)):
+            return list(value)
+        else:
+            return [value]
+
+    def to_python(self, value):
+        if isinstance(value, (tuple, list)):
+            return list(value)
+        else:
+            return [value]
+
+    @property
+    def json_schema(self):
+        return {"type": ["array", "string"], "items": {"type": "string"}}
+
+
+JsonSchemaMixin.register_field_encoders(
+    {
+        ListOrTuple: ListOrTupleEncoder(),
+        Union[ListOrTuple, str]: ListOrTupleOrAloneEncoder(),
+        Union[str, ListOrTuple]: ListOrTupleOrAloneEncoder(),
+    }
+)
+
+
+@dataclass
+class Foo(JsonSchemaMixin):
+    thing: Union[ListOrTuple, str]
+
+
+def test_registered():
+    first = Foo(thing="one")
+    second = Foo(thing=["two", "2"])
+    third = Foo(thing=("three", "3"))
+
+    assert first.to_dict() == {"thing": ["one"]}
+    assert Foo.from_dict({"thing": "one"}) == Foo(thing=["one"])
+
+    assert second.to_dict() == {"thing": ["two", "2"]}
+    assert Foo.from_dict({"thing": ["two", "2"]}) == second
+
+    assert third.to_dict() == {"thing": ["three", "3"]}
+    # dicts must be valid json
+    with pytest.raises(ValidationError):
+        Foo.from_dict({"thing": ("three", "3")})


### PR DESCRIPTION
Make registered encoders go first when finding encoders/decoders/schemas. This way you can successfully override an encoder for a specific subtype of things (see the test for an example of why I care).

I also made errors when finding encoders/decoders/schemas into hard errors - mysteriously non-encoding values are very annoying and never what I want.