### PR TITLE
Make ValidationError match jsonschema.ValidationError, cache schemas

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -34,7 +34,7 @@ JsonEncodable = Union[int, float, str, bool, type(None)]
 JsonDict = Dict[str, Any]
 
 
-class ValidationError(Exception):
+class ValidationError(validator.ValidationError):
     pass
 
 
@@ -733,8 +733,8 @@ class JsonSchemaMixin:
     def validate(cls, data: Any):
         try:
             validator.validate(data, cls.json_schema())
-        except validator.ValidationError as e:
-            raise ValidationError(str(e)) from e
+        except validator.ValidationError as exc:
+            raise ValidationError.create_from(exc) from exc
 
 
 def NewPatternProperty(target: T) -> Type[Dict[str, T]]:

--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -433,7 +433,7 @@ class JsonSchemaMixin:
         return decoder(field, field_type, value)
 
     @classmethod
-    def _find_matching_jsonschema(cls: Type[T], data: JsonDict) -> T:
+    def _find_matching_validator(cls: Type[T], data: JsonDict) -> T:
         if cls is not JsonSchemaMixin:
             raise NotImplementedError
 
@@ -448,7 +448,7 @@ class JsonSchemaMixin:
                 continue
 
         if decoded is None:
-            raise ValidationError("No matching jsonschema for data.")
+            raise ValidationError("No matching validator for data.")
 
         return decoded
 
@@ -456,7 +456,7 @@ class JsonSchemaMixin:
     def from_dict(cls: Type[T], data: JsonDict, validate=True) -> T:
         """Returns a dataclass instance with all nested classes converted from the dict given"""
         if cls is JsonSchemaMixin:
-            return cls._find_matching_jsonschema(data)
+            return cls._find_matching_validator(data)
 
         init_values: Dict[str, Any] = {}
         non_init_values: Dict[str, Any] = {}


### PR DESCRIPTION
This PR raises a ValidationError that contains the full rich information provided by jsonschema, so we can use it to make the output a bit shorter when dbt displays errors about failed validations. Nobody cares about the full schema most of the time!

Also, during validation, cache calls to `validate_schema`/`json_schema` - this is a bit convoluted because you can't hash `dict`s, but you can hash types.
