### PR TITLE
make hologram happy with mypy

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             python setup.py develop
-            pip install black pytest
+            pip install black pytest mypy
             
       - run:
           name: "Check code formatting"
@@ -39,6 +39,12 @@ jobs:
           command: |
             . venv/bin/activate
             pytest
+
+      - run:
+          name: "Run mypy"
+          command: |
+            . venv/bin/activate
+            mypy hologram
 
   py37:
     docker:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+mypy_path = ./third-party-stubs

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requires = [
     'dataclasses;python_version<"3.7"',
 ]
 
-package_version = "0.0.1"
+package_version = "0.0.2a1"
 
 
 def read(f):

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,12 +1,14 @@
 import pytest
 
 from dataclasses import dataclass
+from typing import NewType
 
 from hologram import ValidationError, JsonSchemaMixin
-from hologram.helpers import NewPatternType
+from hologram.helpers import register_pattern
 
 
-Uppercase = NewPatternType("Uppercase", r"[A-Z]+")
+Uppercase = NewType("Uppercase", str)
+register_pattern(Uppercase, r"[A-Z]+")
 
 
 @dataclass

--- a/third-party-stubs/jsonschema/__init__.pyi
+++ b/third-party-stubs/jsonschema/__init__.pyi
@@ -1,0 +1,11 @@
+from typing import Any, Dict, Iterable
+
+# we need the 'as' to tell mypy we want this visible with both names
+from jsonschema.exceptions import ValidationError as ValidationError
+
+
+class Draft7Validator:
+    def __init__(self, schema: Dict[str, Any]) -> None: ...
+    @classmethod
+    def check_schema(cls, schema: Dict[str, Any]) -> None: ...
+    def iter_errors(self, instance, _schema=None) -> Iterable[ValidationError]: ...

--- a/third-party-stubs/jsonschema/exceptions.pyi
+++ b/third-party-stubs/jsonschema/exceptions.pyi
@@ -1,0 +1,26 @@
+from typing import Any, Optional, Tuple, Iterable, TypeVar, Type
+
+# we need this to denote that create_from applies to subclasses
+T = TypeVar('T', bound=ValidationError)
+
+
+class ValidationError(Exception):
+    def __init__(
+        self,
+        message: str,
+        validator: Any = ...,
+        path: Tuple[str] = ...,
+        cause: Optional[Any] = ...,
+        context: Tuple[Any] = ...,
+        validator_value: Any = ...,
+        instance: Any = ...,
+        schema: Any = ...,
+        schema_path: Tuple[Any] = ...,
+        parent: Any = ...,
+    ) -> None: ...
+
+    @classmethod
+    def create_from(cls: Type[T], ValidationError) -> T: ...
+
+
+def best_match(errors: Iterable[ValidationError]) -> ValidationError: ...


### PR DESCRIPTION
Add mypy support to hologram. This also smooths out some of the rough edges with interaction between hologram and mypy.

Breaking Change: Because `NewType`s can't be defined dynamically and mypy explicitly enforces that it's called with a string literal, users will have to pass a NewType(name, str) in to a new function (`register_pattern`). I don't think this is "better", but I don't really think it's worse. Maybe patterns should be metadata like restrict is instead of a standalone field encoder? It's hard to say.
 - I have a dbt branch that fixes the call sites, once we release 0.0.2 I can point it there

I added `  #type: ignore` to a few places that mypy struggled with.
 - `dataclasses.Field` is a weird object and mypy gets confused. I think this is a mypy bug of some kind, but you probably aren't supposed to be messing with the `default_factory` attribute.
 - It doesn't know that you can declare a new enum type using `Enum(x, x)` and to be fair I didn't either. If nobody's using StrLiteral with the advent of restricted fields it can also just go away.
 - The default implementation of `FieldEncoder` makes some assumptions about types, which mypy complains about. If it doesn't work for a type, subclasses will just have to override it.

added third-party stubs for jsonschema, so this includes a mypy.ini.
mypy passes now and runs it in circle