### PR TITLE
Fix: better decode errors + union decoding/encoding

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -512,7 +512,7 @@ class JsonSchemaMixin:
 
             if decoder is None:
                 raise ValidationError(
-                    f"Unable to decode value for '{field}: {field_type_name}'"
+                    f"Unable to decode value for '{field}: {field_type_name}' (value={value})"
                 )
                 return value
             cls._decode_cache[field_type] = decoder

--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -281,11 +281,6 @@ class JsonSchemaMixin:
                 def encoder(ft, v, __):
                     return cls._field_encoders[ft].to_wire(v)
 
-            elif is_optional(field_type):
-
-                def encoder(ft, val, o):
-                    return cls._encode_field(ft.__args__[0], val, o)
-
             elif is_enum(field_type):
 
                 def encoder(_, v, __):
@@ -335,9 +330,22 @@ class JsonSchemaMixin:
                         for k, v in val.items()
                     }
 
-            elif field_type_name in ("Sequence", "List") or (
+            elif field_type_name == "List" or (
                 field_type_name == "Tuple" and ... in field_type.__args__
             ):
+
+                def encoder(ft, val, o):
+                    if not isinstance(val, (tuple, list)):
+                        valtype = type(val)
+                        # raise a TypeError so the union encoder will capture it
+                        raise TypeError(
+                            f"Invalid type, expected {field_type_name} but got {valtype}"
+                        )
+                    return [
+                        cls._encode_field(ft.__args__[0], v, o) for v in val
+                    ]
+
+            elif field_type_name == "Sequence":
 
                 def encoder(ft, val, o):
                     return [
@@ -436,11 +444,6 @@ class JsonSchemaMixin:
                 def decoder(_, ft, val):
                     return ft.from_dict(val, validate=validate)
 
-            elif is_optional(field_type):
-
-                def decoder(f, ft, val):
-                    return cls._decode_field(f, ft.__args__[0], val, validate)
-
             elif field_type_name == "Union":
                 # Attempt to decode the value using each decoder in turn
                 union_excs = (
@@ -474,13 +477,29 @@ class JsonSchemaMixin:
                         for k, v in val.items()
                     }
 
-            elif field_type_name in ("Sequence", "List") or (
+            elif field_type_name == "List" or (
                 field_type_name == "Tuple" and ... in field_type.__args__
             ):
                 seq_type = tuple if field_type_name == "Tuple" else list
 
                 def decoder(f, ft, val):
+                    if not isinstance(val, (tuple, list)):
+                        valtype = type(val)
+                        # raise a TypeError so the Union decoder will capture it
+                        raise TypeError(
+                            f"Invalid type, expected {field_type_name} but got {valtype}"
+                        )
                     return seq_type(
+                        cls._decode_field(f, ft.__args__[0], v, validate)
+                        for v in val
+                    )
+
+            # if you want to allow strings as sequences for some reason, you
+            # can still use 'Sequence' to get back a list of characters...
+            elif field_type_name == "Sequence":
+
+                def decoder(f, ft, val):
+                    return list(
                         cls._decode_field(f, ft.__args__[0], v, validate)
                         for v in val
                     )

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,0 +1,51 @@
+import pytest
+
+from dataclasses import dataclass
+from typing import Union, Optional, List
+
+from hologram import JsonSchemaMixin, ValidationError
+
+
+@dataclass
+class IHaveAnnoyingUnions(JsonSchemaMixin):
+    my_field: Optional[Union[List[str], str]]
+
+
+@dataclass
+class IHaveAnnoyingUnionsReversed(JsonSchemaMixin):
+    my_field: Optional[Union[str, List[str]]]
+
+
+def test_union_decoding():
+    for field_value in (None, [">=0.0.0"], ">=0.0.0"):
+        obj = IHaveAnnoyingUnions(my_field=field_value)
+        dct = {"my_field": field_value}
+        decoded = IHaveAnnoyingUnions.from_dict(dct)
+        assert decoded == obj
+        assert obj.to_dict(omit_none=False) == dct
+
+    # this is allowed, for backwards-compatibility reasons
+    IHaveAnnoyingUnions(my_field=(">=0.0.0",)) == {"my_field": (">=0.0.0",)}
+
+
+def test_union_decoding_ordering():
+    for field_value in (None, [">=0.0.0"], ">=0.0.0"):
+        obj = IHaveAnnoyingUnionsReversed(my_field=field_value)
+        dct = {"my_field": field_value}
+        decoded = IHaveAnnoyingUnionsReversed.from_dict(dct)
+        assert decoded == obj
+        assert obj.to_dict(omit_none=False) == dct
+
+    # this is allowed, for backwards-compatibility reasons
+    IHaveAnnoyingUnionsReversed(my_field=(">=0.0.0",)) == {
+        "my_field": (">=0.0.0",)
+    }
+
+
+def test_union_decode_error():
+    x = IHaveAnnoyingUnions(my_field={">=0.0.0"})
+    with pytest.raises(ValidationError):
+        x.to_dict(validate=True)
+
+    with pytest.raises(ValidationError):
+        IHaveAnnoyingUnions.from_dict({"my_field": {">=0.0.0"}})


### PR DESCRIPTION
When encoding unions like `Union[List[str], str]`, hologram currently behaves differently than `Union[str, List[str]]`, because it treats strings as lists and decodes `'asdf'` as `['a', 's', 'd', 'f]` depending upon which comes out first in Union.__args__. There's a similar weird issue with Unions including `None` that get eagerly decoded into only the first possible member of the union, which is wrong! Instead, skip handling for those fields and let the union encoder/decoder take care of it.

This PR makes hologram a bit more picky about what types can get coerced into `List[T]`/`Tuple[T, ...]` - and as a consequence, the tests I added in `tests/test_union.py` pass. I also left separate support for `Sequence` if for some reason you want to treat strings as sequences of characters.