### PR TITLE
improve thread safety

### DIFF
--- a/hologram/helpers.py
+++ b/hologram/helpers.py
@@ -2,7 +2,7 @@ from dataclasses import fields
 from enum import Enum
 from typing import Type
 
-from hologram import JsonSchemaMixin, FieldEncoder, JsonDict
+from hologram import JsonSchemaMixin, FieldEncoder
 
 
 class StrEnum(str, Enum):
@@ -48,8 +48,4 @@ class HyphenatedJsonSchemaMixin(JsonSchemaMixin):
 
 
 class ExtensibleJsonSchemaMixin(JsonSchemaMixin):
-    @classmethod
-    def _collect_json_schema(cls, definitions: JsonDict) -> JsonDict:
-        dct = super()._collect_json_schema(definitions=definitions)
-        dct["additionalProperties"] = True
-        return dct
+    ADDITIONAL_PROPERTIES = True


### PR DESCRIPTION
Some fixes to provide thread safety in hologram.

Before this patch, if you called `json_schema()` for the same object across multiple threads at the same time, you would (sometimes!) get a `SchemaError` about `None is not of type 'object', 'boolean'` with references to `schema['definitions']`. The fix is to create a global lock around all writes to `_schema`, with checks for the happy path to avoid hitting the lock too frequently.