### PR TITLE
Fix/union none multiple

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -793,7 +793,7 @@ class JsonSchemaMixin:
     @classmethod
     def _get_field_definitions(cls, field_type: Any, definitions: JsonDict):
         field_type_name = cls._get_field_type_name(field_type)
-        if is_optional(field_type) or field_type_name in (
+        if (is_optional(field_type) and len(field_type.__args__) == 2) or field_type_name in (
             "Sequence",
             "List",
             "Tuple",

--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -179,7 +179,7 @@ def _get_restrictions(variant_type: Type) -> Restriction:
 
 
 def get_union_fields(
-    field_type: Union[Any]
+    field_type: Union[Any],
 ) -> Tuple[List[RestrictedVariant], List[Any]]:
     """
     Unions have a __args__ that is all their variants (after typing's

--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -793,11 +793,9 @@ class JsonSchemaMixin:
     @classmethod
     def _get_field_definitions(cls, field_type: Any, definitions: JsonDict):
         field_type_name = cls._get_field_type_name(field_type)
-        if (is_optional(field_type) and len(field_type.__args__) == 2) or field_type_name in (
-            "Sequence",
-            "List",
-            "Tuple",
-        ):
+        if (
+            is_optional(field_type) and len(field_type.__args__) == 2
+        ) or field_type_name in ("Sequence", "List", "Tuple",):
             cls._get_field_definitions(field_type.__args__[0], definitions)
         elif field_type_name in ("Dict", "Mapping"):
             cls._get_field_definitions(field_type.__args__[1], definitions)

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -60,4 +60,3 @@ def test_decode():
         HasRestricted.from_dict(
             {"thing": {"foo": "c", "baz": 20}}, validate=True
         )
-

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -1,0 +1,63 @@
+import pytest
+
+from dataclasses import dataclass, field
+from typing import Union, NewType
+
+from hologram import JsonSchemaMixin, ValidationError
+from hologram.helpers import StrEnum
+
+
+class MySelector(StrEnum):
+    A = "a"
+    B = "b"
+    C = "c"
+
+
+@dataclass
+class RestrictAB(JsonSchemaMixin):
+    foo: MySelector = field(
+        metadata={"restrict": [MySelector.A, MySelector.B]}
+    )
+    bar: int
+
+
+@dataclass
+class RestrictC(JsonSchemaMixin):
+    foo: MySelector = field(metadata={"restrict": [MySelector.C]})
+    baz: str
+
+
+@dataclass
+class HasRestricted(JsonSchemaMixin):
+    thing: Union[RestrictAB, RestrictC, None]
+
+
+# def test_encode():
+#     x = HasRestricted(thing=RestrictAB(foo=MySelector.A, bar=20))
+#     assert x.to_dict() == {"thing": {"foo": "a", "bar": 20}}
+
+#     y = HasRestricted(thing=1000)
+#     assert y.to_dict() == {"thing": 1000}
+
+#     z = HasRestricted(thing=RestrictC(foo=MySelector.C, baz="hi"))
+#     assert z.to_dict() == {"thing": {"foo": "c", "baz": "hi"}}
+
+#     with pytest.raises(ValidationError):
+#         x = HasRestricted(thing=RestrictAB(foo=MySelector.C, bar=20))
+#         x.to_dict(validate=True)
+
+
+def test_decode():
+    x = HasRestricted(thing=RestrictAB(foo=MySelector.A, bar=20))
+    assert (
+        HasRestricted.from_dict(
+            {"thing": {"foo": "a", "bar": 20}}, validate=True
+        )
+        == x
+    )
+
+    with pytest.raises(ValidationError):
+        HasRestricted.from_dict(
+            {"thing": {"foo": "c", "baz": 20}}, validate=True
+        )
+

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dataclasses import dataclass, field
-from typing import Union, NewType
+from typing import Union, NewType, Optional
 
 from hologram import JsonSchemaMixin, ValidationError
 from hologram.helpers import StrEnum
@@ -26,10 +26,18 @@ class RestrictC(JsonSchemaMixin):
     foo: MySelector = field(metadata={"restrict": [MySelector.C]})
     baz: str
 
+@dataclass
+class A(JsonSchemaMixin):
+    baz: str
+
+@dataclass
+class B(JsonSchemaMixin):
+    baz: str
+
 
 @dataclass
 class HasRestricted(JsonSchemaMixin):
-    thing: Union[RestrictAB, RestrictC, None]
+    thing: Union[A, Optional[Union[RestrictAB, RestrictC]], B]
 
 
 def test_encode():

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -32,19 +32,19 @@ class HasRestricted(JsonSchemaMixin):
     thing: Union[RestrictAB, RestrictC, None]
 
 
-# def test_encode():
-#     x = HasRestricted(thing=RestrictAB(foo=MySelector.A, bar=20))
-#     assert x.to_dict() == {"thing": {"foo": "a", "bar": 20}}
+def test_encode():
+    x = HasRestricted(thing=RestrictAB(foo=MySelector.A, bar=20))
+    assert x.to_dict() == {"thing": {"foo": "a", "bar": 20}}
 
-#     y = HasRestricted(thing=1000)
-#     assert y.to_dict() == {"thing": 1000}
+    y = HasRestricted(thing=1000)
+    assert y.to_dict() == {"thing": 1000}
 
-#     z = HasRestricted(thing=RestrictC(foo=MySelector.C, baz="hi"))
-#     assert z.to_dict() == {"thing": {"foo": "c", "baz": "hi"}}
+    z = HasRestricted(thing=RestrictC(foo=MySelector.C, baz="hi"))
+    assert z.to_dict() == {"thing": {"foo": "c", "baz": "hi"}}
 
-#     with pytest.raises(ValidationError):
-#         x = HasRestricted(thing=RestrictAB(foo=MySelector.C, bar=20))
-#         x.to_dict(validate=True)
+    with pytest.raises(ValidationError):
+        x = HasRestricted(thing=RestrictAB(foo=MySelector.C, bar=20))
+        x.to_dict(validate=True)
 
 
 def test_decode():

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -68,3 +68,20 @@ def test_decode():
         HasRestricted.from_dict(
             {"thing": {"foo": "c", "baz": 20}}, validate=True
         )
+
+
+@dataclass
+class IHaveExtremelyAnnoyingUnions(JsonSchemaMixin):
+    my_field: Union[Optional[str], bool, float] = None
+
+
+def test_evil_union():
+    pairs = [
+        (IHaveExtremelyAnnoyingUnions(my_field=True).to_dict(), {"my_field": True}),
+        (IHaveExtremelyAnnoyingUnions(my_field='1').to_dict(), {"my_field": '1'}),
+        (IHaveExtremelyAnnoyingUnions(my_field=1.0).to_dict(), {"my_field": 1.0}),
+        (IHaveExtremelyAnnoyingUnions().to_dict(), {}),
+    ]
+    for a, b in pairs:
+        assert a == b
+        assert IHaveExtremelyAnnoyingUnions.from_dict(b).to_dict() == a

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -27,7 +27,6 @@ class RestrictC(JsonSchemaMixin):
     baz: str
 
 
-
 @dataclass
 class HasRestricted(JsonSchemaMixin):
     thing: Union[RestrictAB, int, RestrictC]

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -27,6 +27,7 @@ class RestrictC(JsonSchemaMixin):
     baz: str
 
 
+
 @dataclass
 class HasRestricted(JsonSchemaMixin):
     thing: Union[RestrictAB, int, RestrictC]


### PR DESCRIPTION
hologram was failing when you gave it a Union with multiple arguments + None -- it was interpreting that as an `Optional` field and short circuiting the schema generation process

the test i added failed before, now it passes