### PR TITLE
Fix union and some tuples

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -793,9 +793,12 @@ class JsonSchemaMixin:
     @classmethod
     def _get_field_definitions(cls, field_type: Any, definitions: JsonDict):
         field_type_name = cls._get_field_type_name(field_type)
-        if (
-            is_optional(field_type) and len(field_type.__args__) == 2
-        ) or field_type_name in ("Sequence", "List", "Tuple",):
+        if field_type_name == "Tuple":
+            # tuples are either like Tuple[T, ...] or Tuple[T1, T2, T3].
+            for member in field_type.__args__:
+                if member is not ...:
+                    cls._get_field_definitions(member, definitions)
+        elif field_type_name in ("Sequence", "List"):
             cls._get_field_definitions(field_type.__args__[0], definitions)
         elif field_type_name in ("Dict", "Mapping"):
             cls._get_field_definitions(field_type.__args__[1], definitions)

--- a/tests/test_multi_optional_definitions.py
+++ b/tests/test_multi_optional_definitions.py
@@ -26,9 +26,11 @@ class RestrictC(JsonSchemaMixin):
     foo: MySelector = field(metadata={"restrict": [MySelector.C]})
     baz: str
 
+
 @dataclass
 class A(JsonSchemaMixin):
     baz: str
+
 
 @dataclass
 class B(JsonSchemaMixin):
@@ -77,9 +79,18 @@ class IHaveExtremelyAnnoyingUnions(JsonSchemaMixin):
 
 def test_evil_union():
     pairs = [
-        (IHaveExtremelyAnnoyingUnions(my_field=True).to_dict(), {"my_field": True}),
-        (IHaveExtremelyAnnoyingUnions(my_field='1').to_dict(), {"my_field": '1'}),
-        (IHaveExtremelyAnnoyingUnions(my_field=1.0).to_dict(), {"my_field": 1.0}),
+        (
+            IHaveExtremelyAnnoyingUnions(my_field=True).to_dict(),
+            {"my_field": True},
+        ),
+        (
+            IHaveExtremelyAnnoyingUnions(my_field="1").to_dict(),
+            {"my_field": "1"},
+        ),
+        (
+            IHaveExtremelyAnnoyingUnions(my_field=1.0).to_dict(),
+            {"my_field": 1.0},
+        ),
         (IHaveExtremelyAnnoyingUnions().to_dict(), {}),
     ]
     for a, b in pairs:

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+from hologram import JsonSchemaMixin
+
+
+@dataclass
+class TupleMember(JsonSchemaMixin):
+    a: int
+
+
+@dataclass
+class TupleEllipsisHolder(JsonSchemaMixin):
+    member: Tuple[TupleMember, ...]
+
+
+@dataclass
+class TupleMemberFirstHolder(JsonSchemaMixin):
+    member: Tuple[TupleMember, str]
+
+
+@dataclass
+class TupleMemberSecondHolder(JsonSchemaMixin):
+    member: Tuple[str, TupleMember]
+
+
+def test_ellipsis_tuples():
+    dct = {"member": [{"a": 1}, {"a": 2}, {"a": 3}]}
+    value = TupleEllipsisHolder(
+        member=(TupleMember(1), TupleMember(2), TupleMember(3))
+    )
+    assert value.to_dict() == dct
+    assert TupleEllipsisHolder.from_dict(dct) == value
+
+
+def test_member_first_tuple():
+    dct = {"member": [{"a": 1}, "a"]}
+    value = TupleMemberFirstHolder(member=(TupleMember(1), "a"))
+    TupleMemberFirstHolder.from_dict(dct) == value
+    value.to_dict() == dct
+
+
+def test_member_second_tuple():
+    dct = {"member": ["a", {"a": 1}]}
+    value = TupleMemberSecondHolder(member=("a", TupleMember(1)))
+    TupleMemberSecondHolder.from_dict(dct) == value
+    value.to_dict() == dct

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -49,3 +49,32 @@ def test_union_decode_error():
 
     with pytest.raises(ValidationError):
         IHaveAnnoyingUnions.from_dict({"my_field": {">=0.0.0"}})
+
+
+@dataclass
+class UnionMember(JsonSchemaMixin):
+    a: int
+
+
+@dataclass
+class LongOptionalUnion(JsonSchemaMixin):
+    # this devolves into Union[None, UnionMember]
+    member: Optional[Union[None, UnionMember]]
+
+
+def test_long_union_decoding():
+    x = LongOptionalUnion(None)
+    x.to_dict() == {"member": None}
+    LongOptionalUnion.from_dict({"member": None})
+
+    x = LongOptionalUnion(UnionMember(1))
+    x.to_dict() == {"member": {"a": 1}}
+    LongOptionalUnion.from_dict({"member": {"a": 1}}) == x
+
+    # x = LongOptionalUnion(UnionMemberB('test'))
+    # x.to_dict() == {'member': {'b': 'test'}}
+    # LongOptionalUnion.from_dict({'member': {'b': 'test'}}) == x
+
+    # x = LongOptionalUnion('value')
+    # x.to_dict() == {'member': 'value'}
+    # LongOptionalUnion.from_dict({'member': 'value'}) == x

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -70,11 +70,3 @@ def test_long_union_decoding():
     x = LongOptionalUnion(UnionMember(1))
     x.to_dict() == {"member": {"a": 1}}
     LongOptionalUnion.from_dict({"member": {"a": 1}}) == x
-
-    # x = LongOptionalUnion(UnionMemberB('test'))
-    # x.to_dict() == {'member': {'b': 'test'}}
-    # LongOptionalUnion.from_dict({'member': {'b': 'test'}}) == x
-
-    # x = LongOptionalUnion('value')
-    # x.to_dict() == {'member': 'value'}
-    # LongOptionalUnion.from_dict({'member': 'value'}) == x


### PR DESCRIPTION
This test fails without this change (with a frustrating validation error):
```
from dataclasses import dataclass
from typing import Tuple

from hologram import JsonSchemaMixin


@dataclass
class TupleMember(JsonSchemaMixin):
    a: int

@dataclass
class TupleMemberSecondHolder(JsonSchemaMixin):
    member: Tuple[str, TupleMember]

TupleMemberSecondHolder.from_dict({"member": ["a", {"a": 1}]})
```

hologram 0.0.6 only checks the first value in a `Tuple`'s `__args__`, but tuples can be of two forms:
 - `Tuple[T, ...]` -> A tuple of any length with members of type `T`
 - `Tuple[T1, T2, T3]` A 3-tuple, where the first member is of type `T1`, the second `T2`, and the third `T2`.

In the second form, tuple members beyond the first are not captured during schema generation.

hologram 0.0.6 also only checks the first member of a `Union` if one member is `None` (that's what `is_optional` checks). That generally works in the case of `typing.Optional[T]`, as it becomes `typing.Union[T, None]`. But hologram does not handle weirder constructions like `typing.Optional[typing.Union[None, T]]` gracefully - that one gets stuck as `typing.Union[None, T]`, so hologram doesn't generate schema information for `T`. The fix for this is to just remove all special handling of options when collecting field descriptions - the `None` values just fall through and you collect all the arguments.