### PR TITLE
Provide min version for jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 requires = [
     "python-dateutil>=2.8,<2.9",
-    "jsonschema<3.2",
+    "jsonschema<3.2,>=3.0",
     'dataclasses==0.6;python_version<"3.7"',
 ]
 


### PR DESCRIPTION
This resolves a failure (below) when using too-old versions of `jsonschema`. Specifically, if 2.6.0 installed, which is the version required by a couple Singer.io plugins, the program will fail to launch.

Here is a traceback:

```
Traceback (most recent call last):
  File "c:\python38\lib\runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python38\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\***\AppData\Roaming\Python\Python38\Scripts\dbt.exe\__main__.py", line 4, in <module>
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\dbt\main.py", line 10, in <module>
    import dbt.version
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\dbt\version.py", line 60, in <module>
    installed = get_installed_version()
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\dbt\version.py", line 24, in get_installed_version
    return dbt.semver.VersionSpecifier.from_version_string(__version__)
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\dbt\semver.py", line 100, in from_version_string
    return cls.from_dict(matched)
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\hologram\__init__.py", line 594, in from_dict
    cls.validate(data)
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\hologram\__init__.py", line 930, in validate
    schema = _validate_schema(cls)
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\hologram\__init__.py", line 153, in _validate_schema
    jsonschema.Draft7Validator.check_schema(schema)
AttributeError: module 'jsonschema' has no attribute 'Draft7Validator'
```
