### PR TITLE
add a test to reach this code path that calls str(), fix bugs

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -44,6 +44,7 @@ class FutureValidationError(ValidationError):
     # a validation error where we haven't called str() on inputs yet.
     def __init__(self, field: str, errors: Dict[str, Exception]):
         self.errors = errors
+        self.field = field
         super().__init__("generic validation error")
         self.initialized = False
 
@@ -67,7 +68,7 @@ class FutureValidationError(ValidationError):
     def __str__(self):
         if not self.initialized:
             self.late_initialize()
-        return super().__str__(self)
+        return super().__str__()
 
 
 def is_enum(field_type: Any) -> bool:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -70,3 +70,10 @@ def test_long_union_decoding():
     x = LongOptionalUnion(UnionMember(1))
     x.to_dict() == {"member": {"a": 1}}
     LongOptionalUnion.from_dict({"member": {"a": 1}}) == x
+
+    with pytest.raises(ValidationError):
+        try:
+            LongOptionalUnion.from_dict({"member": {"b": 1}}, validate=False)
+        except ValidationError as exc:
+            str(exc)
+            raise


### PR DESCRIPTION
Almost nothing actually calls `str()` on validation errors from unvalidated json (hence the perf improvement...), but if you did, 0.0.9 had a couple bugs. I got so excited by the performance I didn't notice this!

I don't think this is reachable from anywhere in dbt, because we always validate unless we made the data in the first place, but I can imagine this coming up.