### PR TITLE
Do not use jsonschema.best_match because it obscures the errors

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -956,6 +956,6 @@ class JsonSchemaMixin:
     def validate(cls, data: Any):
         schema = _validate_schema(cls)
         validator = jsonschema.Draft7Validator(schema)
-        error = jsonschema.exceptions.best_match(validator.iter_errors(data))
+        error = next(iter(validator.iter_errors(data)), None)
         if error is not None:
             raise ValidationError.create_from(error) from error

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,7 +1,8 @@
 import pytest
 
 from dataclasses import dataclass
-from typing import Union, Optional, List
+from typing import Union, Optional, List, Dict, Any
+import re
 
 from hologram import JsonSchemaMixin, ValidationError
 
@@ -76,4 +77,21 @@ def test_long_union_decoding():
             LongOptionalUnion.from_dict({"member": {"b": 1}}, validate=False)
         except ValidationError as exc:
             str(exc)
+            raise
+
+
+@dataclass
+class UnionDefinition(JsonSchemaMixin):
+    my_field: Union[str, Dict[str, Any]]
+
+
+def test_union_definition():
+    dct = {"my_field": ["string_a", "string_b"]}
+    with pytest.raises(ValidationError):
+        try:
+            UnionDefinition.from_dict(dct)
+        except ValidationError as exc:
+            assert exc.validator == "oneOf"
+            assert re.search("'type': 'string'", str(exc))
+            assert re.search("'type': 'object'", str(exc))
             raise


### PR DESCRIPTION
The 'best_match' code in jsonschema was switching to the "first" error encountered and so the exception didn't have all of the information that we want. This is for issue #2700 in dbt.