### PR TITLE
(#34) Add support for Python 3.9

### DIFF
--- a/hologram/__init__.py
+++ b/hologram/__init__.py
@@ -960,6 +960,6 @@ class JsonSchemaMixin:
     def validate(cls, data: Any):
         schema = _validate_schema(cls)
         validator = jsonschema.Draft7Validator(schema)
-        error = jsonschema.exceptions.best_match(validator.iter_errors(data))
+        error = next(iter(validator.iter_errors(data)), None)
         if error is not None:
             raise ValidationError.create_from(error) from error


### PR DESCRIPTION
Fixes #34

This PR updates Hologram's type inference code to be compatible with changes in Python 3.9. Previously, Optional types were treated as `Union[_type_, None]`. In Python 3.9, the Optional type is preserved directly. This PR replaces logic that checks for Union types with corresponding logic that checks for Optional types.

I smoke tested this locally, but would be _great_ to run the dbt integration tests on Py39 while pointing to this hologram branch