### PR TITLE
chore: allow dataclasses to up up to 0.9 excluding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 requires = [
     "python-dateutil>=2.8,<2.9",
     "jsonschema<3.2,>=3.0",
-    'dataclasses==0.6;python_version<"3.7"',
+    'dataclasses>=0.6,<0.9;python_version<"3.7"',
 ]
 
 package_version = "0.0.13"


### PR DESCRIPTION
resolves #39 

## Aim

As discussed here: https://github.com/fishtown-analytics/dbt/issues/3150 and here https://github.com/fishtown-analytics/hologram/issues/39

I'm relaxing the dataclasses version to be a little more permissive on the hologram side.

This will be followed by a PR in dbt core to try out integration tests.